### PR TITLE
Update to deploy RHEL 9.6 bastion/jump host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.tfstate
 *.tfstate.backup
 .terraform*
+jumphost-key
+jumphost-key.pub

--- a/main.tf
+++ b/main.tf
@@ -156,7 +156,7 @@ resource "aws_key_pair" "jumphost_key_pair" {
 }
 
 resource "aws_instance" "jumphost" {
-  ami = data.aws_ami.rhel8.id
+  ami = data.aws_ami.rhel9.id
   instance_type = "t3.micro"
   key_name = aws_key_pair.jumphost_key_pair.key_name
   vpc_security_group_ids = [
@@ -171,12 +171,12 @@ resource "aws_instance" "jumphost" {
 #!/bin/bash
 set -e -x
 
-sudo dnf install -y wget curl python36 python36-devel net-tools gcc libffi-devel openssl-devel jq bind-utils podman
+sudo dnf install -y wget curl python3 python3-devel net-tools gcc libffi-devel openssl-devel jq bind-utils podman
 
-wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-amd64-rhel9.tar.gz
 
 mkdir openshift
-tar -zxvf openshift-client-linux.tar.gz -C openshift
+tar -zxvf openshift-client-linux-amd64-rhel9.tar.gz -C openshift
 sudo install openshift/oc /usr/local/bin/oc
 sudo install openshift/kubectl /usr/local/bin/kubectl
 EOF

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,29 @@ data "aws_ami" "rhel8" {
 
 }
 
+data "aws_ami" "rhel9" {
+  most_recent      = true
+  owners           = ["219670896067"]
+
+  filter {
+    name   = "name"
+    values = ["RHEL-9.6*"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+}
+
 variable "name" {
   type        = string
   description = "ROSA cluster name"


### PR DESCRIPTION
Current deployment creates a RHEL 8.6 jump host. This PR updates the deployment to use a RHEL 9.6 public AMI.
The PR also ensures the AMI comes from Red Hat using the AWS GovCloud ownerID for RedHat
PR also switches openshift client tools to the RHEL 9 set.